### PR TITLE
Remove unused DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
     android:installLocation="auto">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission
+        android:name="${applicationId}.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION"         
+        tools:node="remove" />
     <uses-feature android:name="android.hardware.camera"/>
 
     <application


### PR DESCRIPTION
This shows up as required permission on e.g. https://f-droid.org/de/packages/org.musicbrainz.picard.barcodescanner/ but actually should not be needed. 

See also https://stackoverflow.com/questions/74146297/android-adding-dynamic-receiver-not-exported-permission-in-release-build